### PR TITLE
Add organization-scoped job numbering system

### DIFF
--- a/components/jobs/job-card.tsx
+++ b/components/jobs/job-card.tsx
@@ -195,9 +195,14 @@ export function JobCard({
           <span className="text-sm font-medium">{getOwnerName()}</span>
         </div>
 
-        {/* Job title */}
+        {/* Job title with job number */}
         <div className="mb-6 pl-6">
-          <h3 className="text-base font-semibold">{currentJob.title}</h3>
+          <div className="flex items-center gap-2">
+            <h3 className="text-base font-semibold">{currentJob.title}</h3>
+            <span className="text-xs font-mono text-gray-500 bg-gray-100 px-2 py-1 rounded">
+              #{currentJob.jobNumber}
+            </span>
+          </div>
         </div>
 
         {/* Bottom section with task count and due date */}

--- a/components/jobs/job-feed-view.tsx
+++ b/components/jobs/job-feed-view.tsx
@@ -33,6 +33,7 @@ function convertJobsToTableData(
 
     return {
       id: job._id,
+      jobNumber: job.jobNumber,
       title: job.title,
       notes: job.notes || undefined,
       businessFunctionId: job.businessFunctionId || undefined,

--- a/components/jobs/table/columns.tsx
+++ b/components/jobs/table/columns.tsx
@@ -17,6 +17,7 @@ import { TasksButton } from "@/components/tasks/tasks-button";
 
 export type Job = {
   id: string;
+  jobNumber: number;
   title: string;
   notes?: string;
   businessFunctionId?: string;
@@ -58,6 +59,20 @@ export const columns = (
     ),
     enableSorting: false,
     enableHiding: false,
+  },
+  {
+    accessorKey: "jobNumber",
+    header: "Job No.",
+    cell: ({ row }) => {
+      const jobNumber = row.getValue("jobNumber") as number;
+      return (
+        <span className="font-mono text-sm text-gray-600">
+          #{jobNumber}
+        </span>
+      );
+    },
+    enableSorting: true,
+    size: 60,
   },
   {
     accessorKey: "title",

--- a/components/landing_page/navbar.tsx
+++ b/components/landing_page/navbar.tsx
@@ -30,6 +30,7 @@ function convertJobsToTableData(
 
     return {
       id: job._id,
+      jobNumber: job.jobNumber,
       title: job.title,
       notes: job.notes || undefined,
       businessFunctionId: job.businessFunctionId || undefined,

--- a/components/tasks/tasks-sidebar.tsx
+++ b/components/tasks/tasks-sidebar.tsx
@@ -913,7 +913,12 @@ const saveTasksOrderSilently = async () => {
             <Card className="mb-6">
               <CardHeader>
                 <CardTitle className="flex items-center justify-between">
-                  <span>{selectedJob.title}</span>
+                  <div className="flex items-center gap-2">
+                    <span>{selectedJob.title}</span>
+                    <span className="text-xs font-mono text-gray-500 bg-gray-100 px-2 py-1 rounded">
+                      #{selectedJob.jobNumber}
+                    </span>
+                  </div>
                 </CardTitle>
               </CardHeader>
               <CardContent>

--- a/lib/models/job.model.ts
+++ b/lib/models/job.model.ts
@@ -14,6 +14,7 @@ export interface Jobs extends mongoose.Document {
   tasks?: string[]; // Array of task IDs associated with this job
   // owner field removed as it's now derived from the next task's owner
   isDeleted: boolean; // Soft delete flag
+  jobNumber: number;
 }
 
 enum level {
@@ -73,6 +74,11 @@ const JobSchema = new mongoose.Schema<Jobs>({
     type: Boolean,
     default: false,
     required: true
+  },
+  jobNumber: {
+    type: Number,
+    required: true,
+    index: true
   }
 });
 

--- a/lib/services/job.service.ts
+++ b/lib/services/job.service.ts
@@ -56,9 +56,9 @@ export class JobService {
 * Migrates jobs that don't have a createdDate field by setting them to a fallback date.
 * This function ensures backward compatibility for jobs created before the createdDate
 * field was implemented, preventing them from showing current timestamps inappropriately.
-* 
-* @description
-* - Connects to the database using dbConnect()
+ * 
+ * @description
+ * - Connects to the database using dbConnect()
 * - Sets fallback date to Mother's Day 2025 (2025-05-11) as a meaningful reference point
 * - Finds all jobs for the specified user that either:
 *   - Don't have a createdDate field (field doesn't exist)
@@ -66,11 +66,11 @@ export class JobService {
 * - Updates all matching jobs with the fallback date
 * - Logs errors to console and re-throws them for upstream handling
 * - Runs automatically before fetching jobs to ensure data consistency
-* 
-* @example
+ * 
+ * @example
 * // Called automatically in getAllJobs before returning job data
 * await this.migrateJobsCreatedDate(userId);
-*/
+ */
 
   async migrateJobsCreatedDate(userId: string): Promise<void> {
   try {
@@ -99,6 +99,7 @@ async getAllJobs(userId: string): Promise<Jobs[]> {
   try {
     await dbConnect();
     await this.migrateJobsCreatedDate(userId);
+    await this.migrateJobNumbers(userId);
     const jobs = await Job.find({ 
       userId, 
       $or: [
@@ -106,7 +107,6 @@ async getAllJobs(userId: string): Promise<Jobs[]> {
         { isDeleted: { $exists: false } }
       ] 
     }).lean();
-    
     
     return JSON.parse(JSON.stringify(jobs));
   } catch (error) {
@@ -125,20 +125,133 @@ async getAllJobs(userId: string): Promise<Jobs[]> {
     }
   }
 
-    async createJob(jobData: Partial<Jobs>, userId: string): Promise<Jobs> {
-      try {
-        await dbConnect();
-        const job = new Job({
-          ...jobData,
-          userId,
-          createdDate: new Date()
-        });
-        const savedJob = await job.save();
-        return JSON.parse(JSON.stringify(savedJob));
-      } catch (error) {
-        throw new Error('Error creating job in database');
-      }
+ /**
+ * Migrates jobs that don't have a jobNumber field by assigning sequential numbers.
+ * This function ensures backward compatibility for jobs created before the jobNumber
+ * field was implemented, maintaining chronological order based on creation date.
+ * 
+ * @description
+ * - Connects to the database using dbConnect()
+ * - Finds all jobs for the specified user that either:
+ *   - Don't have a jobNumber field (field doesn't exist)
+ *   - Have a null jobNumber value
+ * - Sorts jobs by createdDate (ascending) then by _id to maintain chronological order
+ * - Gets the highest existing jobNumber for the user as starting point
+ * - Assigns sequential numbers starting from (lastJobNumber + 1)
+ * - Updates all jobs without numbers in a single batch operation
+ * - Logs migration progress to console for monitoring
+ * - Runs automatically before fetching jobs to ensure data consistency
+ * 
+ * @example
+ * // Called automatically in getAllJobs before returning job data
+ * await this.migrateJobNumbers(userId);
+ * 
+ * // Existing jobs without numbers get sequential IDs:
+ * // Job A (created first) -> #1
+ * // Job B (created second) -> #2
+ * // Job C (created third) -> #3
+ */ 
+
+async migrateJobNumbers(userId: string): Promise<void> {
+  try {
+    await dbConnect();
+    
+    const jobsWithoutNumbers = await Job.find({ 
+      userId, 
+      $or: [
+        { jobNumber: { $exists: false } },
+        { jobNumber: null }
+      ]
+    }).sort({ createdDate: 1, _id: 1 }).lean();
+
+    if (jobsWithoutNumbers.length === 0) {
+      return;
     }
+
+    const lastNumberedJob = await Job.findOne({ 
+      userId, 
+      jobNumber: { $exists: true, $ne: null } 
+    }).sort({ jobNumber: -1 }).select('jobNumber').lean() as { jobNumber?: number } | null;
+
+    let nextNumber = (lastNumberedJob?.jobNumber || 0) + 1;
+
+    const updatePromises = jobsWithoutNumbers.map(job => 
+      Job.updateOne(
+        { _id: job._id },
+        { $set: { jobNumber: nextNumber++ } }
+      )
+    );
+
+    await Promise.all(updatePromises);
+    
+    console.log(`Migrated ${jobsWithoutNumbers.length} jobs with job numbers for user ${userId}`);
+  } catch (error) {
+    console.error('Error migrating job numbers:', error);
+    throw error;
+  }
+}
+
+/**
+ * Generates the next sequential job number for a specific view context.
+ * Ensures each view context (personal or organization) has their own independent 
+ * numbering sequence starting from 1. In organization contexts, all members
+ * share the same numbering sequence for collaborative job management.
+ * 
+ * @description
+ * - Queries the database to find the highest existing jobNumber for the view context
+ * - Returns the next number in sequence (lastJobNumber + 1)
+ * - If no jobs exist for the view context, starts numbering from 1
+ * - Includes fallback error handling using job count as backup
+ * - Used during job creation to assign unique, sequential identifiers
+ * - Numbers are scoped per view context to ensure uniqueness within each context
+ * - Personal contexts get independent numbering from organization contexts
+ * 
+ * @example
+ * // Personal context - user has jobs #1, #2, #5 in their personal space
+ * const nextNumber = await this.getNextJobNumber("user_123");
+ * // Returns: 6 (highest + 1, regardless of gaps)
+ * 
+ * // Organization context - org has jobs #1, #2, #3 created by various members
+ * const nextOrgNumber = await this.getNextJobNumber("org_456");
+ * // Returns: 4 (next in sequence, shared across all org members)
+ * 
+ * // New view context with no jobs
+ * const firstNumber = await this.getNextJobNumber("new_context_id");
+ * // Returns: 1
+ */
+
+private async getNextJobNumber(userId: string): Promise<number> {
+  try {
+    const lastJob = await Job.findOne({ userId })
+      .sort({ jobNumber: -1 })
+      .select('jobNumber')
+      .lean() as { jobNumber?: number } | null;
+    
+    return (lastJob?.jobNumber || 0) + 1;
+  } catch (error) {
+    console.error('Error getting next job number:', error);
+    const jobCount = await Job.countDocuments({ userId });
+    return jobCount + 1;
+  }
+}
+
+async createJob(jobData: Partial<Jobs>, userId: string): Promise<Jobs> {
+  try {
+    await dbConnect();
+    const nextJobNumber = await this.getNextJobNumber(userId);
+ 
+    const job = new Job({
+      ...jobData,
+      userId,
+      jobNumber: nextJobNumber,
+      createdDate: new Date()
+    });
+    const savedJob = await job.save();
+    return JSON.parse(JSON.stringify(savedJob));
+  } catch (error) {
+    throw new Error('Error creating job in database');
+  }
+}
 
   async updateJob(id: string, userId: string, updateData: Partial<Jobs>): Promise<Jobs | null> {
     try {


### PR DESCRIPTION
Added job numbers to make it easier to reference and discuss specific jobs. Now every job gets a sequential number like #1, #2, #3, which appears next to the job title throughout the app.

The numbering is smart about organizations - when you're in your personal workspace, you get your own numbering sequence. When you're in a shared organization, everyone sees the same job numbers so the team can easily reference "Job #47" in conversations. All existing jobs automatically get numbers assigned based on when they were created, so there's no disruption. The job numbers show up in the job cards (job-feed-view), table view, and task sidebar with GitHub issue style formatting.