### PR TITLE
fixed gcal link in onboarding tour

### DIFF
--- a/app/settings/layout.tsx
+++ b/app/settings/layout.tsx
@@ -1,0 +1,9 @@
+import Layout from "../layouts/layout";
+
+export default function SettingsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <Layout>{children}</Layout>;
+} 

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -70,4 +70,4 @@ export default function FeedPage() {
       
 
   );
-}
+} 

--- a/components/dashboard/app-sidebar.tsx
+++ b/components/dashboard/app-sidebar.tsx
@@ -522,7 +522,7 @@ export function AppSidebar() {
               asChild
               className="flex items-center"
             >
-              <Link href="/dashboard/settings">
+              <Link href="/settings">
                 <Settings className={!isMobile && effectiveState === "collapsed" ? "mx-auto" : ""} />
                 <span className={!isMobile && effectiveState === "collapsed" ? "hidden" : ""}>
                   Settings

--- a/components/gcal/calendar-auth.tsx
+++ b/components/gcal/calendar-auth.tsx
@@ -28,25 +28,27 @@ export default function CalendarAuth() {
 
   return (
     <div className="space-y-4">
-      <Button onClick={handleAuth} disabled={isAuthorizing} id="authorize-gcal">
-        {isAuthorizing ? "Authorizing..." : "Authorize Google Calendar"}
-      </Button>
+      <div className="flex gap-4">
+        <Button onClick={handleAuth} disabled={isAuthorizing} id="authorize-gcal">
+          {isAuthorizing ? "Authorizing..." : "Authorize Google Calendar"}
+        </Button>
 
-      <Button
-        onClick={handleGetCalenders}
-        disabled={isGetting}
-        id="get-calendars"
-      >
-        {isGetting ? "Getting..." : "Get Calendars"}
-      </Button>
+        <Button
+          onClick={handleGetCalenders}
+          disabled={isGetting}
+          id="get-calendars"
+        >
+          {isGetting ? "Getting..." : "Get Calendars"}
+        </Button>
 
-      <Button
-        onClick={handleCreatePrioriCalendar}
-        disabled={isCreating}
-        id="create-prioriwise-calendar"
-      >
-        {isCreating ? "Creating..." : "Create Prioriwise Calendar"}
-      </Button>
+        <Button
+          onClick={handleCreatePrioriCalendar}
+          disabled={isCreating}
+          id="create-prioriwise-calendar"
+        >
+          {isCreating ? "Creating..." : "Create Prioriwise Calendar"}
+        </Button>
+      </div>
 
       {calendars.length > 0 && (
         <div className="space-y-2">

--- a/components/onboarding_tour/driver-tour.tsx
+++ b/components/onboarding_tour/driver-tour.tsx
@@ -68,7 +68,7 @@ export default function DriverTour({ onTourEnd }: DriverTourProps): React.ReactE
               }
               
               // Redirect to settings calendar page with tour parameter
-              window.location.href = '/dashboard/settings?tab=calendar&tour=gcal&step=0';
+              window.location.href = '/settings?tab=calendar&tour=gcal&step=0';
               
               // Return false to prevent default next action
               return false;


### PR DESCRIPTION
Fixed the onboarding link for google calendar. Now the "go to calendar" link takes the user to the settings > calendar tab and the onboarding continues from there.